### PR TITLE
Log upstream_response_time

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -17,7 +17,7 @@ http {
 
   server_tokens off;
 
-  log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id country=$country edgescape=$http_X_Akamai_Edgescape';
+  log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id upstream_response_time=$upstream_response_time country=$country edgescape=$http_X_Akamai_Edgescape';
   access_log logs/nginx/access.log l2met;
   error_log logs/nginx/error.log;
 
@@ -40,9 +40,11 @@ http {
     server_name _;
     #keepalive_timeout 5;
 
-    location ~* (collections|live|products|epg|schedule|fullproducts|playlists|headers) {
-      rewrite schedule epg permanent;
+    location /schedule {
+       rewrite ^/schedule(.*) http://$server_name/shop/issues/custom_issue_name$1 permanent;
+     }
 
+    location ~* (collections|live|products|epg|fullproducts|playlists|headers) {
       include cors_support;
       gzip on;
       set $no_cache "";

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -40,11 +40,9 @@ http {
     server_name _;
     #keepalive_timeout 5;
 
-    location /schedule {
-       rewrite ^/schedule(.*) http://$server_name/shop/issues/custom_issue_name$1 permanent;
-     }
+    location ~* (collections|live|products|epg|schedule|fullproducts|playlists|headers) {
+      rewrite schedule epg permanent;
 
-    location ~* (collections|live|products|epg|fullproducts|playlists|headers) {
       include cors_support;
       gzip on;
       set $no_cache "";


### PR DESCRIPTION
Just added upstream_response_time

Currently the staging is build of this `time` branch, I've made all the upstreams are still alive:
SEARCH
https://rbtv-gsd-staging.herokuapp.com/v3/search?q=jumps
BENDER
https://rbtv-gsd-staging.herokuapp.com/v3/products
BOXY
https://rbtv-gsd-staging.herokuapp.com/v3/session
DEWEY
https://rbtv-gsd-staging.herokuapp.com/v3/resources/adventure/rbtv_display_art_square